### PR TITLE
Add shim to avoid test warning

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,8 @@
             "error",
             {
                 "devDependencies": [
-                    "testSetup.ts",
+                    "setupTestFramework.js",
+                    "testSetup.js",
                     "**/*.test.js",
                     "**/*.spec.js"
                 ]

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   },
   "jest": {
     "collectCoverage": true,
+    "collectCoverageFrom": [
+      "src/**/*.{js,jsx,ts,tsx}"
+    ],
     "coverageDirectory": "./coverage/",
     "coveragePathIgnorePatterns": [
       "/node_modules/",
@@ -25,7 +28,8 @@
       "tsx",
       "js"
     ],
-    "setupTestFrameworkScriptFile": "./testSetup.ts",
+    "setupFiles": ["<rootDir>/testShims.js", "<rootDir>/testSetup.ts"],
+    "setupTestFrameworkScriptFile": "<rootDir>/setupTestFramework.ts",
     "testRegex": "(/__test__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "transform": {
       ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"

--- a/setupTestFramework.ts
+++ b/setupTestFramework.ts
@@ -1,0 +1,7 @@
+/**
+ * This file contains any modifications that extend the functionality provided by 'jest'.
+ *
+ * Any modifications to 'expect' should be done here.
+ */
+
+import 'jest-styled-components';

--- a/src/components/__tests__/Container.spec.tsx
+++ b/src/components/__tests__/Container.spec.tsx
@@ -1,7 +1,7 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import Container from '../Container';
+import { Container } from '../';
 
 
 const setup = ({ ...rest } = {}) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,0 @@
-export * from './components';
-export * from './typography';

--- a/src/typography/__tests__/Heading.spec.tsx
+++ b/src/typography/__tests__/Heading.spec.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import { default as defaultTheme, ITheme } from '../../theme';
 
-import Heading from '../Heading';
+import { Heading } from '../';
 
 
 const setup = ({ theme = defaultTheme } = {}) => {

--- a/src/typography/__tests__/Text.spec.tsx
+++ b/src/typography/__tests__/Text.spec.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import { default as defaultTheme, ITheme } from '../../theme';
 
-import Text from '../Text';
+import { Text } from '../';
 
 
 const setup = ({ theme = defaultTheme } = {}) => {

--- a/testSetup.ts
+++ b/testSetup.ts
@@ -1,7 +1,5 @@
 import * as Enzyme from 'enzyme';
 import * as Adapter from 'enzyme-adapter-react-16';
 
-import 'jest-styled-components';
-
 
 Enzyme.configure({ adapter: new Adapter() });

--- a/testShims.js
+++ b/testShims.js
@@ -1,0 +1,7 @@
+/**
+ * Any shims required for running tests.
+ */
+
+global.requestAnimationFrame = (callback) => {
+  setTimeout(callback, 0);
+};


### PR DESCRIPTION
Fixes #3

This PR adds a shim for `requestAnimationFrame` which is required by React for rendering during tests.